### PR TITLE
Suppress yt-dl error and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:10-buster
+RUN apt-get update && apt-get install -y build-essential ffmpeg
+RUN curl -L https://yt-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl
+RUN chmod a+rx /usr/local/bin/youtube-dl
+RUN npm install -g node-gyp
+WORKDIR /bot
+COPY . .
+RUN npm install
+WORKDIR /bot/node_modules/jitterbuffer
+RUN node-gyp rebuild
+WORKDIR /bot/node_modules/node-opus
+RUN node-gyp rebuild
+WORKDIR /bot
+CMD ["npm","start"]

--- a/src/ytdl.js
+++ b/src/ytdl.js
@@ -6,7 +6,7 @@ var downloads = new Map();
 
 exports.details = function(url) {
 	return new Promise((resolve, reject) => {
-		let args = ["-j", "--no-playlist", "--playlist-items", "1"];
+		let args = ["-j", "--no-playlist", "--playlist-items", "1", "--restrict-filenames"];
 		if (global.config.proxy) {
 			args.push("--proxy");
 			args.push(global.config.proxy);


### PR DESCRIPTION
No idea why node-gyp doesn't build jitterbuffer & node-opus right away but I don't feel like debugging that.